### PR TITLE
Use x86_64 for amd64 architecture in yamlfmt url

### DIFF
--- a/tools/yamlfmt/task_darwin.yaml
+++ b/tools/yamlfmt/task_darwin.yaml
@@ -8,8 +8,10 @@ tasks:
     vars:
       TEMP_DIR:
         sh: mktemp -d
+      # YAMLfmt uses x86_64 instead of amd64
+      FIXED_ARCH: '{{if eq ARCH "amd64"}}x86_64{{else}}{{ARCH}}{{end}}'
     cmds:
       - defer: rm -rf {{.TEMP_DIR}}
-      - curl -Lo {{.TEMP_DIR}}/yamlfmt.tar.gz https://github.com/google/yamlfmt/releases/download/v0.9.0/yamlfmt_0.9.0_Darwin_{{ARCH}}.tar.gz
+      - curl -Lo {{.TEMP_DIR}}/yamlfmt.tar.gz https://github.com/google/yamlfmt/releases/download/v0.9.0/yamlfmt_0.9.0_Darwin_{{.FIXED_ARCH}}.tar.gz
       - tar -xvf {{.TEMP_DIR}}/yamlfmt.tar.gz -C {{.TEMP_DIR}}
       - sudo mv {{.TEMP_DIR}}/yamlfmt /usr/local/bin/yamlfmt


### PR DESCRIPTION
To test the change, pull this repo/branch locally and run:

```sh
task yamlfmt:install --force
```

The `--force` will skip any checks that yamlfmt is already installed.