### PR TITLE
add some common pulumi and python tasks

### DIFF
--- a/tools/pulumi/task.yaml
+++ b/tools/pulumi/task.yaml
@@ -11,3 +11,13 @@ tasks:
       - pulumi version
     cmds:
       - task: os:install
+
+  preview:
+    desc: Preview pulumi stack
+    cmds:
+      - pulumi preview
+
+  up:
+    desc: Update pulumi stack
+    cmds:
+      - pulumi up {{.CLI_ARGS}}

--- a/tools/pulumi/task.yaml
+++ b/tools/pulumi/task.yaml
@@ -21,3 +21,8 @@ tasks:
     desc: Update pulumi stack
     cmds:
       - pulumi up {{.CLI_ARGS}}
+
+  import:
+    desc: Import resources into the pulumi stack
+    cmds:
+      - pulumi import {{.CLI_ARGS}}

--- a/tools/pulumi/task.yaml
+++ b/tools/pulumi/task.yaml
@@ -26,3 +26,8 @@ tasks:
     desc: Import resources into the pulumi stack
     cmds:
       - pulumi import {{.CLI_ARGS}}
+
+  refresh:
+    desc: Refresh pulumi stack
+    cmds:
+      - pulumi refresh {{.CLI_ARGS}}

--- a/tools/python/task.yaml
+++ b/tools/python/task.yaml
@@ -19,7 +19,7 @@ tasks:
     cmds:
       - python3 -m pip install poetry
 
-  init_project:
+  init:
     desc: Initialize poetry in a new project and install common dev dependencies
     vars:
       FLAKE8_CONFIG: |
@@ -37,17 +37,17 @@ tasks:
           --dev-dependency flake8 \
           --dev-dependency isort
 
-  init:
+  setup:
     desc: Initialize project (run poetry install)
     cmds:
       - poetry install
 
   format:
-    - .venv/bin/black .
-    - .venv/bin/isort .
+    - poetry run -- black .
+    - poetry run -- isort .
 
   lint:
-    - .venv/bin/flake8 . --count --statistics
-    - .venv/bin/black . --check
-    - .venv/bin/isort . --check-only
+    - poetry run -- flake8 . --count --statistics
+    - poetry run -- black . --check
+    - poetry run -- isort . --check-only
 

--- a/tools/python/task.yaml
+++ b/tools/python/task.yaml
@@ -18,3 +18,36 @@ tasks:
       - python3 -m pip show poetry &>/dev/null
     cmds:
       - python3 -m pip install poetry
+
+  init_project:
+    desc: Initialize poetry in a new project and install common dev dependencies
+    vars:
+      FLAKE8_CONFIG: |
+        [flake8]
+        ignore = E501
+        max-complexity = 10
+        exclude = .git,__pycache__,.venv,.mypy_cache,venv
+        max-line-length = 120
+        per-file-ignores = __init__.py:F401,__main__.py:E402
+    cmds:
+      - echo "{{.FLAKE8_CONFIG}}" > .flake8
+      - |
+        poetry init \
+          --dev-dependency black \
+          --dev-dependency flake8 \
+          --dev-dependency isort
+
+  init:
+    desc: Initialize project (run poetry install)
+    cmds:
+      - poetry install
+
+  format:
+    - .venv/bin/black .
+    - .venv/bin/isort .
+
+  lint:
+    - .venv/bin/flake8 . --count --statistics
+    - .venv/bin/black . --check
+    - .venv/bin/isort . --check-only
+


### PR DESCRIPTION
This adds some tasks to setup an new python project, perform python linting and formatting, and also run pulumi preview and update commands. Pulumi commands typically rely on values defined in a .env file. I've included the .env file in my projects Taskfile. I'm not sure if there is a way to standardize this. Open to suggestions. 